### PR TITLE
Promote K8s 1.10.4 and Linkerd 1.4.2 to cncf.ci

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -73,7 +73,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.10.2"
+    stable_ref: "v1.10.3"
     head_ref: "master"
     app_layer: false
   prometheus: 
@@ -101,7 +101,7 @@ projects:
     project_url: "https://github.com/coredns/coredns"
     repository_url: "https://github.com/coredns/coredns"
     timeout: 350 
-    stable_ref: "v1.1.2"
+    stable_ref: "v1.1.3"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
@@ -116,7 +116,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.2.0"
+    stable_ref: "v1.2.1"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"
@@ -131,7 +131,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.4.0"
+    stable_ref: "1.4.1"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -73,7 +73,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.10.3"
+    stable_ref: "v1.10.4"
     head_ref: "master"
     app_layer: false
   prometheus: 
@@ -131,7 +131,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.4.1"
+    stable_ref: "1.4.2"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -44,18 +44,22 @@ clouds:
     active: true
     display_name: OpenStack
     order: 9
+  oracle: 
+    active: false
+    display_name: Oracle
+    order: 10
   testcloud90: 
     active: false
     display_name: Open Stacko
-    order: 10
+    order: 11
   testcloud91: 
     active: false
     display_name: Open Stacken
-    order: 11
+    order: 12
   testcloud92: 
     active: false
     display_name: Open Stacking
-    order: 12
+    order: 13
     
 
 projects:
@@ -69,7 +73,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.9.6"
+    stable_ref: "v1.10.1"
     head_ref: "master"
     app_layer: false
   prometheus: 
@@ -97,7 +101,7 @@ projects:
     project_url: "https://github.com/coredns/coredns"
     repository_url: "https://github.com/coredns/coredns"
     timeout: 350 
-    stable_ref: "v1.1.1"
+    stable_ref: "v1.1.2"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
@@ -112,7 +116,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.1.2"
+    stable_ref: "v1.1.3"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"
@@ -127,7 +131,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.3.6"
+    stable_ref: "1.3.7"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -73,7 +73,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.10.1"
+    stable_ref: "v1.10.2"
     head_ref: "master"
     app_layer: false
   prometheus: 
@@ -116,7 +116,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.1.3"
+    stable_ref: "v1.2.0"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"
@@ -131,7 +131,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.3.7"
+    stable_ref: "1.4.0"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"


### PR DESCRIPTION
- K8s 1.10.4
- Linkerd 1.4.2