### PR TITLE
Update Prometheus 2.3.0, Linkerd 1.4.3 and Fluentd 1.2.2 on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -116,7 +116,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.2.1"
+    stable_ref: "v1.2.2"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"
@@ -131,7 +131,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.4.2"
+    stable_ref: "1.4.3"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -86,7 +86,7 @@ projects:
     project_url: "https://github.com/prometheus/prometheus"
     repository_url: "https://github.com/prometheus/prometheus"
     timeout: 600
-    stable_ref: "v2.2.1"
+    stable_ref: "v2.3.0"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"


### PR DESCRIPTION
Updates:
- Prometheus 2.3.0, 
- Linkerd 1.4.3 
- Fluentd 1.2.2 
