### PR TITLE
Update display name for VMware vSphere

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -46,7 +46,7 @@ clouds:
     order: 9
   vsphere:
     active: true
-    display_name: VMware Cloud on AWS
+    display_name: VMware vSphere
     order: 10
   oracle: 
     active: false


### PR DESCRIPTION
VMware would like this to say VMware vSphere instead of VMware Cloud on AWS
- looks good on cidev
- merge to staging