### PR TITLE
Update display name to VMware vSphere on cncf.ci

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -44,22 +44,26 @@ clouds:
     active: true
     display_name: OpenStack
     order: 9
+  vsphere:
+    active: true
+    display_name: VMware Cloud on AWS
+    order: 10
   oracle: 
     active: false
     display_name: Oracle
-    order: 10
+    order: 11
   testcloud90: 
     active: false
     display_name: Open Stacko
-    order: 11
+    order: 12
   testcloud91: 
     active: false
     display_name: Open Stacken
-    order: 12
+    order: 13
   testcloud92: 
     active: false
     display_name: Open Stacking
-    order: 13
+    order: 14
     
 
 projects:
@@ -73,7 +77,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.10.5"
+    stable_ref: "v1.11.0"
     head_ref: "master"
     app_layer: false
   prometheus: 

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -46,7 +46,7 @@ clouds:
     order: 9
   vsphere:
     active: true
-    display_name: VMware Cloud on AWS
+    display_name: VMware vSphere
     order: 10
   oracle: 
     active: false


### PR DESCRIPTION
VMware would like this to say VMware vSphere instead of VMware Cloud on AWS

- looks good on staging
- merge to cncf.ci