### PR TITLE
Enable Linkerd 1.4.4 on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -135,7 +135,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.4.3"
+    stable_ref: "1.4.4"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"


### PR DESCRIPTION
Update Linkerd 1.4.4
- builds work as expected on cidev
- merge and test on staging