### PR TITLE
Enable CoreDNS v1.2.0 and Fluentd v1.2.3 on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -105,7 +105,7 @@ projects:
     project_url: "https://github.com/coredns/coredns"
     repository_url: "https://github.com/coredns/coredns"
     timeout: 350 
-    stable_ref: "v1.1.4"
+    stable_ref: "v1.2.0"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
@@ -120,7 +120,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.2.2"
+    stable_ref: "v1.2.3"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"


### PR DESCRIPTION
Project release updates: 
- CoreDNS v1.2.0
- Fluentd v1.2.3
- looks good on cidev
- needs tested on staging