### PR TITLE
promote CoreDNS and Envoy release updates to staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -171,7 +171,7 @@ projects:
     project_url: "https://github.com/envoyproxy/envoy"
     repository_url: "https://github.com/envoyproxy/envoy"
     timeout: 2100
-    stable_ref: "v1.7.1"
+    stable_ref: "v1.8.0"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -53,7 +53,7 @@ clouds:
     display_name: oreocloud
     order: 11
   oci: 
-    active: false
+    active: true
     display_name: Oracle Cloud Infrastructure
     order: 12
   testcloud90: 

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -109,7 +109,7 @@ projects:
     project_url: "https://github.com/coredns/coredns"
     repository_url: "https://github.com/coredns/coredns"
     timeout: 350 
-    stable_ref: "v1.2.2"
+    stable_ref: "v1.2.3"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"


### PR DESCRIPTION
- enable CoreDNS v1.2.3
- enable Envoy v1.8.0
- enable OCI