### PR TITLE
promote Prometheus, CoreDNS, Fluentd updates to staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -171,7 +171,7 @@ projects:
     project_url: "https://github.com/envoyproxy/envoy"
     repository_url: "https://github.com/envoyproxy/envoy"
     timeout: 2100
-    stable_ref: "v1.8.0"
+    stable_ref: "v1.9.0"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -81,7 +81,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.12.3"
+    stable_ref: "v1.13.0"
     head_ref: "master"
     app_layer: false
   prometheus: 

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -124,7 +124,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.3.0"
+    stable_ref: "v1.3.1"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -81,7 +81,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.12.2"
+    stable_ref: "v1.12.3"
     head_ref: "master"
     app_layer: false
   prometheus: 
@@ -139,7 +139,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.5.1"
+    stable_ref: "1.5.2"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -94,7 +94,7 @@ projects:
     project_url: "https://github.com/prometheus/prometheus"
     repository_url: "https://github.com/prometheus/prometheus"
     timeout: 600
-    stable_ref: "v2.4.3"
+    stable_ref: "v2.5.0"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
@@ -109,7 +109,7 @@ projects:
     project_url: "https://github.com/coredns/coredns"
     repository_url: "https://github.com/coredns/coredns"
     timeout: 350 
-    stable_ref: "v1.2.5"
+    stable_ref: "v1.2.6"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -124,7 +124,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.2.6"
+    stable_ref: "v1.3.0"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"


### PR DESCRIPTION
- update Prometheus release to v2.5.0
- update CoreDNS release to v1.2.6
- update  Fluentd release to v1.3.0