### PR TITLE
update stable releases on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -81,7 +81,7 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 900
-    stable_ref: "v1.13.0"
+    stable_ref: "v1.13.3"
     head_ref: "master"
     app_layer: false
   prometheus: 
@@ -94,7 +94,7 @@ projects:
     project_url: "https://github.com/prometheus/prometheus"
     repository_url: "https://github.com/prometheus/prometheus"
     timeout: 600
-    stable_ref: "v2.5.0"
+    stable_ref: "v2.7.1"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
@@ -109,7 +109,7 @@ projects:
     project_url: "https://github.com/coredns/coredns"
     repository_url: "https://github.com/coredns/coredns"
     timeout: 350 
-    stable_ref: "v1.2.6"
+    stable_ref: "v1.3.1"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
@@ -124,7 +124,7 @@ projects:
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
     timeout: 500
-    stable_ref: "v1.3.1"
+    stable_ref: "v1.3.3"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"
@@ -139,7 +139,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     timeout: 1500
-    stable_ref: "1.5.2"
+    stable_ref: "1.6.1"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"


### PR DESCRIPTION
- update CoreDNS: v1.3.1
- update Kubernetes: v1.13.3
- update Prometheus: v2.7.1
- update Fluentd: v1.3.3
- update Linkerd: 1.6.1

All Project builds were successful on ci dev, 
Skipping dev for today (under construction), 
Promoting updated stable releases to staging for QA