### PR TITLE
Update order of projects on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -85,7 +85,7 @@ projects:
     head_ref: "master"
     app_layer: false
   prometheus: 
-    order: 2
+    order: 4
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
     display_name: Prometheus
@@ -100,7 +100,7 @@ projects:
     head_chart: "stable"
     app_layer: true
   coredns: 
-    order: 3
+    order: 2
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/coredns/icon/color/core-dns-icon-color.png"
     display_name: CoreDNS
@@ -115,7 +115,7 @@ projects:
     head_chart: "stable"
     app_layer: true
   fluentd: 
-    order: 4
+    order: 5
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/bcabeb288a5c934278acd20b479ab8da494f2711/fluentd/icon/color/fluentd-icon-color.png"
     display_name: Fluentd
@@ -130,7 +130,7 @@ projects:
     head_chart: "cncf"
     app_layer: true
   linkerd: 
-    order: 5
+    order: 6
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
@@ -162,7 +162,7 @@ projects:
     container_image_url: "https://nexus3.onap.org:10001/openecomp/mso"
     head_base_job_url: "https://jenkins.onap.org/view/Daily-Jobs/job/so-master-docker-version-java-daily"
   envoy:
-    order: 6
+    order: 3
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
     display_name: Envoy


### PR DESCRIPTION
Manually update order of projects (based on maturity/alpha): 
* to be automated in https://github.com/crosscloudci/crosscloudci/issues/120

1 - Kubernetes - to be shown in Test Environment section at top of screen
2 - CoreDNS (Graduated)
3 - Envoy (Graduated)
4 - Prometheus (Graduated)
5 - Fluentd (Incubating)
6 - Linkerd (Incubating)
7 - ONAP (Linux Foundation)