### PR TITLE
update fluentd stable release on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -127,7 +127,7 @@ projects:
     repository_url: "https://github.com/fluent/fluentd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration/master/cncfci.yml"
     timeout: 500
-    stable_ref: "v1.4.0"
+    stable_ref: "v1.4.1"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"


### PR DESCRIPTION
- enable fluentd v1.4.1 on staging
- not promoting from master due to "development mode"
