### PR TITLE
update project releases on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -88,7 +88,7 @@ projects:
     order: 4
     active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
-    display_name: Prometheus
+    display_name: PrometheusDEV
     sub_title: Monitoring
     gitlab_name: prometheus
     project_url: "https://github.com/prometheus/prometheus"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -86,7 +86,7 @@ projects:
     app_layer: false
   prometheus: 
     order: 4
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
     display_name: Prometheus
     sub_title: Monitoring
@@ -118,7 +118,7 @@ projects:
     app_layer: true
   fluentd: 
     order: 5
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/bcabeb288a5c934278acd20b479ab8da494f2711/fluentd/icon/color/fluentd-icon-color.png"
     display_name: Fluentd
     sub_title: Logging
@@ -134,7 +134,7 @@ projects:
     app_layer: true
   linkerd: 
     order: 6
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
     sub_title: Service Mesh
@@ -150,7 +150,7 @@ projects:
     app_layer: true
   so:
     order: 7
-    active: true
+    active: false
     logo_url: "https://github.com/crosscloudci/artwork/raw/master/ONAP/logo_onap_2017-square.png"
     display_name: ONAP
     sub_title: Network Automation
@@ -168,7 +168,7 @@ projects:
     head_base_job_url: "https://jenkins.onap.org/view/Daily-Jobs/job/so-master-docker-version-java-daily"
   envoy:
     order: 3
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
     display_name: Envoy
     sub_title: Service Mesh

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -86,7 +86,7 @@ projects:
     app_layer: false
   prometheus: 
     order: 4
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
     display_name: Prometheus
     sub_title: Monitoring
@@ -134,7 +134,7 @@ projects:
     app_layer: true
   linkerd: 
     order: 6
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
     sub_title: Service Mesh
@@ -150,7 +150,7 @@ projects:
     app_layer: true
   so:
     order: 7
-    active: false
+    active: true
     logo_url: "https://github.com/crosscloudci/artwork/raw/master/ONAP/logo_onap_2017-square.png"
     display_name: ONAP
     sub_title: Network Automation
@@ -168,7 +168,7 @@ projects:
     head_base_job_url: "https://jenkins.onap.org/view/Daily-Jobs/job/so-master-docker-version-java-daily"
   envoy:
     order: 3
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
     display_name: Envoy
     sub_title: Service Mesh

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -86,7 +86,7 @@ projects:
     app_layer: false
   prometheus: 
     order: 4
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
     display_name: Prometheus
     sub_title: Monitoring
@@ -131,7 +131,7 @@ projects:
     app_layer: true
   linkerd: 
     order: 6
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
     sub_title: Service Mesh
@@ -146,7 +146,7 @@ projects:
     app_layer: true
   so:
     order: 7
-    active: true
+    active: false
     logo_url: "https://github.com/crosscloudci/artwork/raw/master/ONAP/logo_onap_2017-square.png"
     display_name: ONAP
     sub_title: Network Automation
@@ -163,7 +163,7 @@ projects:
     head_base_job_url: "https://jenkins.onap.org/view/Daily-Jobs/job/so-master-docker-version-java-daily"
   envoy:
     order: 3
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
     display_name: Envoy
     sub_title: Service Mesh

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -88,11 +88,12 @@ projects:
     order: 4
     active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
-    display_name: PrometheusDEV
+    display_name: Prometheus
     sub_title: Monitoring
     gitlab_name: prometheus
     project_url: "https://github.com/prometheus/prometheus"
     repository_url: "https://github.com/prometheus/prometheus"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/prometheus-configuration/master/cncfci.yml"
     timeout: 600
     stable_ref: "v2.8.0"
     head_ref: "master"
@@ -108,6 +109,7 @@ projects:
     gitlab_name: coredns
     project_url: "https://github.com/coredns/coredns"
     repository_url: "https://github.com/coredns/coredns"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/coredns-configuration/master/cncfci.yml"
     timeout: 350 
     stable_ref: "v1.4.0"
     head_ref: "master"
@@ -123,6 +125,7 @@ projects:
     gitlab_name: fluentd
     project_url: "https://github.com/fluent/fluentd"
     repository_url: "https://github.com/fluent/fluentd"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration/master/cncfci.yml"
     timeout: 500
     stable_ref: "v1.4.0"
     head_ref: "master"
@@ -138,6 +141,7 @@ projects:
     gitlab_name: linkerd
     project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/linkerd-configuration/master/cncfci.yml"
     timeout: 1500
     stable_ref: "1.6.2"
     head_ref: "master"
@@ -153,6 +157,7 @@ projects:
     gitlab_name: so
     project_url: "https://github.com/onap/so"
     repository_url: "https://github.com/onap/so"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/onap-so-configuration/master/cncfci.yml"
     timeout: 2100
     stable_ref: "v1.1.1"
     head_ref: "master"
@@ -170,6 +175,7 @@ projects:
     gitlab_name: envoy
     project_url: "https://github.com/envoyproxy/envoy"
     repository_url: "https://github.com/envoyproxy/envoy"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/envoy-configuration/master/cncfci.yml"
     timeout: 2100
     stable_ref: "v1.9.0"
     head_ref: "master"


### PR DESCRIPTION
Promote release updates from integration to staging:

- enable CoreDNS v1.5.0
- enable Envoy v1.10.0
- enable Prometheus v2.8.1
- enable Fluentd v1.4.2

Skipping dev environment due to work in progress. 
