### PR TITLE
QA sub-headers and project relation on staging

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -173,7 +173,7 @@ projects:
     app_layer: true
     arch:
       - "amd64"
-    cncf_relation: "Incubating" 
+    cncf_relation: "Graduated" 
   so:
     order: 7
     active: true


### PR DESCRIPTION
https://github.com/crosscloudci/crosscloudci/issues/120

Temporarily changing line 176 on staging
- from  cncf_relation: "Incubating" 
- to   cncf_relation: "Graduated" 

Will revert back after testing