### PR TITLE
QA sub-headers and relation on dev

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -174,7 +174,7 @@ projects:
     app_layer: true
     arch:
       - "amd64"
-    cncf_relation: "Incubating" 
+    cncf_relation: "Graduated" 
   so:
     order: 7
     active: true


### PR DESCRIPTION
crosscloudci/crosscloudci#120

Temporarily changing line 177 on master

from cncf_relation: "Incubating"
to cncf_relation: "Graduated"

Will revert back after QA passes A/C