### PR TITLE
QA Fluentd release deleted line 149

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -146,7 +146,6 @@ projects:
     repository_url: "https://github.com/fluent/fluentd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration/master/cncfci.yml"
     timeout: 2700
-#    stable_ref: "v1.5.2"
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"


### PR DESCRIPTION
QA Fluentd per-project release details on staging

Deleted line 149
#    stable_ref: "v1.5.2"