### PR TITLE
enable CoreDNS v1.5.2 on cidev

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -120,7 +120,7 @@ projects:
     repository_url: "https://github.com/coredns/coredns"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/coredns-configuration/master/cncfci.yml"
     timeout: 2700 
-    stable_ref: "v1.5.1"
+    stable_ref: "v1.5.2"
     head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"


### PR DESCRIPTION
- enable CoreDNS v1.5.2