### PR TITLE
QA if Linkerd is Graduated

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -167,7 +167,7 @@ projects:
     app_layer: true
     arch:
       - "amd64"
-    cncf_relation: "Incubating" 
+    cncf_relation: "Graduated" 
   so:
     order: 7
     active: true


### PR DESCRIPTION
then Incubating sub-header should not be displayed