### PR TITLE
Promote K8s v1.16.2 & fluentd chart fix to production

### DIFF
--- a/ADDAPROJECT.md
+++ b/ADDAPROJECT.md
@@ -1,0 +1,114 @@
+# CNCF CI New Project Setup
+
+The goal is to call the new project's ci scripts from gitlabs ci 
+configuration file
+
+## CI Setup
+
+1.  Clone the project
+
+```
+git clone yourprojectname
+```	
+```
+- e.g. git clone https://github.com/envoyproxy/envoy.git
+```
+
+2.  Make a note of any ci instructions including
+scripts for building and publishing images
+
+- e.g. the .circleci/config.yml file outlines lots of shell scripts
+that refer to a docker dependencies image and build image
+
+3. Replicate the builds
+
+- e.g. use docker to replicate a build image using the previously viewed ci 
+- you probably want to pin your image
+- update the script not to push 
+- images will be local after build
+- publish to gitlab directory
+
+4. Create a script that builds head 
+
+5. Create a script that builds stable
+
+
+
+## Gitlab Setup
+### GitLab Pipeline Setup
+***You need to have admin permissions to do this***
+
+In Gitlab you need to complete the following steps.
+ 1. Create a new group
+ 2. Create a new project
+ 3. Set up mirroring (*steps and menu items in gitlab*)
+    - Botuser needs to be in user permissions
+        - Add member
+        - master
+    - Impersonate bot user
+        - Admin
+            - Search for bot, click on bot user
+            - Impersonate
+    - Settings
+        - Repository
+            - Pull from remote repository
+            - Select mirror, add https repo address, select bot user
+    - Project
+        - Should see that the code is pulled down
+    - Stop impersonating
+4. Set up project variables (*steps and menu items in gitlab*)
+    - Settings
+        - Pipeline trigger
+	  - add trigger
+	  - copy token
+	  - put in environment.rb
+	- Pipelines 
+            - Custom ci config path
+                - e.g. https://raw.githubusercontent.com/crosscloudci/envoy-configuration/master/.gitlab-ci.yml
+            - Add cloud variable
+                - CLOUD
+                  - e.g.  aws
+		- ARCH
+		- GEMFURY
+		- TOKEN
+		  - token from earlier pipeline trigger step
+5. Enable runners (*steps and menu items in gitlab*)
+    - Admin
+        - Runners
+            - Select token
+                - Select envoy
+6. Add to dashboard script (*steps and menu items in gitlab*)
+    - Cncf configuration
+        - Integration branch
+            - Add to cross-cloud.yml
+            - Duplicate a project
+            - Find logo image e.g. https://d33wubrfki0l68.cloudfront.net/77bb2db951dc11d54851e79e0ca09e3a02b276fa/9c0b7/img/envoy-logo.svg
+                - Add to cncf artwork repo
+                - Link to cross cloud artwork repo
+            - Rename the project names to envoy etc
+            - Charts are the repo that we get the helm charts from
+            - Change timeout for how long your build takes
+7. Review pipelines
+	- Pipelines
+        - manually add new to the url (***this is a workaround***)
+            - e.g. https://gitlab.cidev.cncf.ci/envoy/envoy/pipelines/new
+        - Select master
+        - Select stable (*e.g. v1.7.0*)
+        - Both should be running
+#### How to Debug
+1. Add a sleep to the .gitlab-ci.yml script
+2. ssh root@runner.yourgitlaburl
+3. Click on compile job
+### Gitlab yml common issue
+- If .gitlab-ci.yml does not refresh: 
+  - Go to pipelines
+  - Copy/cut the gitlab.yml and save an empty url
+  - Paste the url in again and save it
+### Gitlab Yml Configuration
+1. Make crosscloudci/<projectname>-configuration project
+2. Edit .gitlab-ci.yml
+    ```
+    e.g. envoy-configuration
+    ```
+  
+

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -167,7 +167,7 @@ projects:
     app_layer: true
     arch:
       - "amd64"
-    cncf_relation: "Graduated" 
+    cncf_relation: "Incubating" 
   so:
     order: 7
     active: true

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -217,7 +217,7 @@ projects:
     project_url: "https://github.com/linkerd/linkerd2"
     repository_url: "https://github.com/linkerd/linkerd2"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/linkerd2-configuration"
-    timeout: 2600
+    timeout: 1200
     stable_chart: "stable"
     head_chart: "stable"
     app_layer: true

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -12,12 +12,12 @@ gitlab_pipeline:
       - "Provisioning"
   project:
     status_jobs:
-      - "baseimage"
-      - "baseimage-arm"
-      - "compile"
-      - "compile-arm"
-      - "container"
       - "container-arm"
+      - "container" 
+      - "compile-arm"      
+      - "compile"     
+      - "baseimage-arm"      
+      - "baseimage"
 clouds:
   aws: 
     active: false
@@ -153,7 +153,7 @@ projects:
     cncf_relation: "Graduated" 
   linkerd: 
     order: 6
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
     sub_title: Service Mesh
@@ -209,7 +209,7 @@ projects:
     cncf_relation: "Graduated" 
   linkerd2: 
     order: 6
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd 2.x
     sub_title: Service Mesh
@@ -221,6 +221,7 @@ projects:
     stable_chart: "stable"
     head_chart: "stable"
     app_layer: true
+    deploy: false
     arch:
       - "amd64"
     cncf_relation: "Incubating"
@@ -238,6 +239,7 @@ projects:
     stable_chart: "stable"
     head_chart: "stable"
     app_layer: true
+    deploy: false
     arch:
       - "amd64"
     cncf_relation: "Linux Foundation" 

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -207,3 +207,37 @@ projects:
       - "amd64"
       - "arm64"
     cncf_relation: "Graduated" 
+  linkerd2: 
+    order: 6
+    active: false
+    logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
+    display_name: Linkerd 2.x
+    sub_title: Service Mesh
+    gitlab_name: linkerd2
+    project_url: "https://github.com/linkerd/linkerd2"
+    repository_url: "https://github.com/linkerd/linkerd2"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/linkerd2-configuration"
+    timeout: 2600
+    stable_chart: "stable"
+    head_chart: "stable"
+    app_layer: true
+    arch:
+      - "amd64"
+    cncf_relation: "Incubating"
+  testproj: 
+    order: 50
+    active: true
+    logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.svg?sanitize=true"
+    display_name: Test Project
+    sub_title: Testing
+    gitlab_name: testproj
+    project_url: "https://github.com/crosscloudci/testproj"
+    repository_url: "https://github.com/crosscloudci/testproj"
+    configuration_repo: "https://raw.githubusercontent.com/crosscloudci/testproj-configuration"
+    timeout: 1200
+    stable_chart: "stable"
+    head_chart: "stable"
+    app_layer: true
+    arch:
+      - "amd64"
+    cncf_relation: "Linux Foundation" 

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -91,7 +91,7 @@ projects:
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/kubernetes-configuration"
     timeout: 1680
     app_layer: false
-    stable_ref: "v1.13.0"
+    stable_ref: "v1.16.2"
     head_ref: "master"
     arch:
       - "amd64"
@@ -144,8 +144,8 @@ projects:
     repository_url: "https://github.com/fluent/fluentd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration"
     timeout: 2700
-    stable_chart: "cncf"
-    head_chart: "cncf"
+    stable_chart: "stable"
+    head_chart: "stable"
     app_layer: true
     arch:
       - "amd64"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -227,7 +227,7 @@ projects:
     cncf_relation: "Incubating"
   testproj: 
     order: 50
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.svg?sanitize=true"
     display_name: Test Project
     sub_title: Testing


### PR DESCRIPTION
## Description

Promote K8s v1.16.2 and use fluentd stable helm chart


issues:
- crosscloudci/crosscloudci#181
- vulk/cncf_ci#265


## Motivation and Context


## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [x] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [x] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [x] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Tested locally
* [ ]  Have not tested

## Types of changes
* [x]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.