### PR TITLE
Promote vitess to production

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -89,6 +89,8 @@ projects:
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 1680
     app_layer: false
+    stable_ref: "v1.13.0"
+    head_ref: "master"
     arch:
       - "amd64"
       - "arm64"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -180,6 +180,8 @@ projects:
     stable_chart: "onap-amsterdam"
     head_chart: "onap-master"
     app_layer: true
+    stable_ref: "v1.1.1"
+    head_ref: "master"
     container_image_url: "https://nexus3.onap.org:10001/openecomp/mso"
     head_base_job_url: "https://jenkins.onap.org/view/Daily-Jobs/job/so-master-docker-version-java-daily"
     arch:

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -147,6 +147,7 @@ projects:
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration/master/cncfci.yml"
     timeout: 2700
     head_ref: "master"
+    stable_ref: "v1.4.0"
     stable_chart: "cncf"
     head_chart: "cncf"
     app_layer: true

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -146,7 +146,6 @@ projects:
     repository_url: "https://github.com/fluent/fluentd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration/master/cncfci.yml"
     timeout: 2700
-    stable_ref:
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -88,8 +88,6 @@ projects:
     project_url: "https://github.com/kubernetes/kubernetes"
     repository_url: "https://github.com/kubernetes/kubernetes"
     timeout: 1680
-    stable_ref: "v1.13.0"
-    head_ref: "master"
     app_layer: false
     arch:
       - "amd64"
@@ -112,8 +110,6 @@ projects:
     arch:
       - "amd64"
       - "arm64"
-    stable_ref: "v2.10.0"
-    head_ref: "master"
     cncf_relation: "Graduated" 
   coredns: 
     order: 2
@@ -126,8 +122,6 @@ projects:
     repository_url: "https://github.com/coredns/coredns"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/coredns-configuration/master/cncfci.yml"
     timeout: 2700 
-    stable_ref: "v1.5.0"
-    head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
     app_layer: true      
@@ -146,8 +140,6 @@ projects:
     repository_url: "https://github.com/fluent/fluentd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration/master/cncfci.yml"
     timeout: 2700
-    head_ref: "master"
-    stable_ref: "v1.4.0"
     stable_chart: "cncf"
     head_chart: "cncf"
     app_layer: true
@@ -166,8 +158,6 @@ projects:
     repository_url: "https://github.com/linkerd/linkerd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/linkerd-configuration/master/cncfci.yml"
     timeout: 2600
-    stable_ref: "1.6.3"
-    head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
     app_layer: true
@@ -185,8 +175,6 @@ projects:
     repository_url: "https://github.com/onap/so"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/onap-so-configuration/master/cncfci.yml"
     timeout: 2100
-    stable_ref: "v1.1.1"
-    head_ref: "master"
     stable_chart: "onap-amsterdam"
     head_chart: "onap-master"
     app_layer: true
@@ -206,8 +194,6 @@ projects:
     repository_url: "https://github.com/envoyproxy/envoy"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/envoy-configuration/master/cncfci.yml"
     timeout: 2100
-    stable_ref: "v1.10.0"
-    head_ref: "master"
     stable_chart: "stable"
     head_chart: "stable"
     app_layer: true

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -146,6 +146,7 @@ projects:
     repository_url: "https://github.com/fluent/fluentd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/fluentd-configuration/master/cncfci.yml"
     timeout: 2700
+    stable_ref:
     head_ref: "master"
     stable_chart: "cncf"
     head_chart: "cncf"


### PR DESCRIPTION
## Description
1.  Adds vitess to cross-cloud.yml
2. Also addes etcd but it is currently disabled as the build is failing

Issues:
- https://github.com/crosscloudci/crosscloudci/issues/35
- https://github.com/vulk/cncf_ci/issues/302

## How Has This Been Tested?
* [x]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [x] dev.cncf.ci
   * [x] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Browser tested on staging.cncf.ci
* [ ]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.