### PR TITLE
Adjust ordering of TUF and Vitess (alphabetical)

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -262,7 +262,7 @@ projects:
       - "amd64"
     cncf_relation: "Incubating"
   vitess:
-    order: 7
+    order: 8
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/vitess/horizontal/color/vitess-horizontal-color.svg?sanitize=true"
     display_name: Vitess
@@ -280,7 +280,7 @@ projects:
       - "amd64"
     cncf_relation: "Graduated"
   tuf:
-    order: 8
+    order: 7
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
     display_name: TUF


### PR DESCRIPTION
## Description
1. adjust ordering so that Graduated Projects are listed in alphabetical order
  - TUF = 7
  - Vitess = 8

Issues:
- maintenance

## How Has This Been Tested?
* [ ]  Covered by existing integration testing
* [ ]  Added integration testing to cover
* [ ] Tested with [trigger client](https://github.com/crosscloudci/crosscloudci-trigger) against 
   * [ ] cidev.cncf.ci
   * [ ] dev.cncf.ci
   * [ ] staging.cncf.ci
   * [ ] cncf.ci (production)
* [x]  Browser tested on staging.cncf.ci
* [ ]  Have not tested

## Types of changes
* [ ]  Bug fix (non-breaking change which fixes an issue)
* [x]  New feature (non-breaking change which adds functionality)
* [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
## Checklist:
* [ ]  My change requires a change to the documentation.
* [ ]  I have updated the documentation accordingly.
* [x] No updates required.