### PR TITLE
update etcd to graduated to production #230

### DIFF
--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -158,7 +158,7 @@ projects:
     display_name: Linkerd
     sub_title: Service Mesh
     gitlab_name: linkerd
-    projec9_url: "https://github.com/linkerd/linkerd"
+    project_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/linkerd-configuration"
     timeout: 2600

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -281,7 +281,7 @@ projects:
     cncf_relation: "Graduated"
   tuf:
     order: 7
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
     display_name: TUF
     sub_title: Software Update Spec

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -153,7 +153,7 @@ projects:
     cncf_relation: "Graduated" 
   linkerd: 
     order: 99
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
     sub_title: Service Mesh
@@ -169,7 +169,7 @@ projects:
       - "amd64"
     cncf_relation: "Incubating" 
   so:
-    order: 10
+    order: 11
     active: true
     logo_url: "https://github.com/crosscloudci/artwork/raw/master/ONAP/logo_onap_2017-square.png"
     display_name: ONAP
@@ -208,7 +208,7 @@ projects:
       - "arm64"
     cncf_relation: "Graduated" 
   linkerd2: 
-    order: 9
+    order: 10
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd 2.x
@@ -299,7 +299,7 @@ projects:
     cncf_relation: "Graduated"
   testproj: 
     order: 50
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.svg?sanitize=true"
     display_name: Test Project
     sub_title: Testing

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -117,7 +117,7 @@ projects:
     cncf_relation: "Graduated" 
   coredns: 
     order: 2
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/coredns/icon/color/core-dns-icon-color.png"
     display_name: CoreDNS
     sub_title: Service Discovery
@@ -135,7 +135,7 @@ projects:
     cncf_relation: "Graduated" 
   fluentd: 
     order: 4
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/bcabeb288a5c934278acd20b479ab8da494f2711/fluentd/icon/color/fluentd-icon-color.png"
     display_name: Fluentd
     sub_title: Logging
@@ -153,7 +153,7 @@ projects:
     cncf_relation: "Graduated" 
   linkerd: 
     order: 99
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
     sub_title: Service Mesh
@@ -170,7 +170,7 @@ projects:
     cncf_relation: "Incubating" 
   so:
     order: 10
-    active: true
+    active: false
     logo_url: "https://github.com/crosscloudci/artwork/raw/master/ONAP/logo_onap_2017-square.png"
     display_name: ONAP
     sub_title: Network Automation
@@ -191,7 +191,7 @@ projects:
     cncf_relation: "Linux Foundation" 
   envoy:
     order: 3
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
     display_name: Envoy
     sub_title: Service Mesh
@@ -209,7 +209,7 @@ projects:
     cncf_relation: "Graduated" 
   linkerd2: 
     order: 9
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd 2.x
     sub_title: Service Mesh
@@ -227,7 +227,7 @@ projects:
     cncf_relation: "Incubating"
   jaeger: 
     order: 5
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/jaeger/icon/color/jaeger-icon-color.svg?sanitize=true"
     display_name: Jaeger
     sub_title: Distributed Tracing
@@ -245,7 +245,7 @@ projects:
     cncf_relation: "Graduated"
   etcd:
     order: 9
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/etcd/icon/color/etcd-icon-color.svg?sanitize=true"
     display_name: etcd
     sub_title: Key/Value Store
@@ -263,7 +263,7 @@ projects:
     cncf_relation: "Incubating"
   vitess:
     order: 8
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/vitess/horizontal/color/vitess-horizontal-color.svg?sanitize=true"
     display_name: Vitess
     sub_title: Storage
@@ -281,7 +281,7 @@ projects:
     cncf_relation: "Graduated"
   tuf:
     order: 7
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
     display_name: TUF
     sub_title: Software Update Spec
@@ -299,7 +299,7 @@ projects:
     cncf_relation: "Graduated"
   testproj: 
     order: 50
-    active: true
+    active: false
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.svg?sanitize=true"
     display_name: Test Project
     sub_title: Testing

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -98,7 +98,7 @@ projects:
       - "arm64"
     cncf_relation: "Graduated"  
   prometheus: 
-    order: 6
+    order: 7
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/prometheus/icon/color/prometheus-icon-color.png"
     display_name: Prometheus
@@ -134,7 +134,7 @@ projects:
       - "arm64"
     cncf_relation: "Graduated" 
   fluentd: 
-    order: 4
+    order: 5
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/bcabeb288a5c934278acd20b479ab8da494f2711/fluentd/icon/color/fluentd-icon-color.png"
     display_name: Fluentd
@@ -158,7 +158,7 @@ projects:
     display_name: Linkerd
     sub_title: Service Mesh
     gitlab_name: linkerd
-    project_url: "https://github.com/linkerd/linkerd"
+    projec9_url: "https://github.com/linkerd/linkerd"
     repository_url: "https://github.com/linkerd/linkerd"
     configuration_repo: "https://raw.githubusercontent.com/crosscloudci/linkerd-configuration"
     timeout: 2600
@@ -226,7 +226,7 @@ projects:
       - "amd64"
     cncf_relation: "Incubating"
   jaeger: 
-    order: 5
+    order: 6
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/jaeger/icon/color/jaeger-icon-color.svg?sanitize=true"
     display_name: Jaeger
@@ -244,7 +244,7 @@ projects:
       - "amd64"
     cncf_relation: "Graduated"
   etcd:
-    order: 9
+    order: 4
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/etcd/icon/color/etcd-icon-color.svg?sanitize=true"
     display_name: etcd
@@ -260,9 +260,9 @@ projects:
     deploy: false
     arch:
       - "amd64"
-    cncf_relation: "Incubating"
+    cncf_relation: "Graduated"
   vitess:
-    order: 8
+    order: 9
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/vitess/horizontal/color/vitess-horizontal-color.svg?sanitize=true"
     display_name: Vitess
@@ -280,7 +280,7 @@ projects:
       - "amd64"
     cncf_relation: "Graduated"
   tuf:
-    order: 7
+    order: 8
     active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
     display_name: TUF

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -281,7 +281,7 @@ projects:
     cncf_relation: "Graduated"
   tuf:
     order: 7
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
     display_name: TUF
     sub_title: Software Update Spec

--- a/cross-cloud.yml
+++ b/cross-cloud.yml
@@ -117,7 +117,7 @@ projects:
     cncf_relation: "Graduated" 
   coredns: 
     order: 2
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/1d4e7cf3b60af40e008b2e2413f7a2d1ff784b52/coredns/icon/color/core-dns-icon-color.png"
     display_name: CoreDNS
     sub_title: Service Discovery
@@ -135,7 +135,7 @@ projects:
     cncf_relation: "Graduated" 
   fluentd: 
     order: 4
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/bcabeb288a5c934278acd20b479ab8da494f2711/fluentd/icon/color/fluentd-icon-color.png"
     display_name: Fluentd
     sub_title: Logging
@@ -153,7 +153,7 @@ projects:
     cncf_relation: "Graduated" 
   linkerd: 
     order: 99
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd
     sub_title: Service Mesh
@@ -170,7 +170,7 @@ projects:
     cncf_relation: "Incubating" 
   so:
     order: 10
-    active: false
+    active: true
     logo_url: "https://github.com/crosscloudci/artwork/raw/master/ONAP/logo_onap_2017-square.png"
     display_name: ONAP
     sub_title: Network Automation
@@ -191,7 +191,7 @@ projects:
     cncf_relation: "Linux Foundation" 
   envoy:
     order: 3
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/ab42c9591f6e0fdccc62c7b88f353d3fdc825734/envoy/icon/color/envoy-icon-color.png"
     display_name: Envoy
     sub_title: Service Mesh
@@ -209,7 +209,7 @@ projects:
     cncf_relation: "Graduated" 
   linkerd2: 
     order: 9
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/53f1179f7950f27e330fce4e983304de59811b52/linkerd/icon/color/linkerd-icon-color.png"
     display_name: Linkerd 2.x
     sub_title: Service Mesh
@@ -227,7 +227,7 @@ projects:
     cncf_relation: "Incubating"
   jaeger: 
     order: 5
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/jaeger/icon/color/jaeger-icon-color.svg?sanitize=true"
     display_name: Jaeger
     sub_title: Distributed Tracing
@@ -245,7 +245,7 @@ projects:
     cncf_relation: "Graduated"
   etcd:
     order: 9
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/etcd/icon/color/etcd-icon-color.svg?sanitize=true"
     display_name: etcd
     sub_title: Key/Value Store
@@ -263,7 +263,7 @@ projects:
     cncf_relation: "Incubating"
   vitess:
     order: 8
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/vitess/horizontal/color/vitess-horizontal-color.svg?sanitize=true"
     display_name: Vitess
     sub_title: Storage
@@ -281,7 +281,7 @@ projects:
     cncf_relation: "Graduated"
   tuf:
     order: 7
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/projects/tuf/icon/color/tuf-icon-color.svg?sanitize=true"
     display_name: TUF
     sub_title: Software Update Spec
@@ -299,7 +299,7 @@ projects:
     cncf_relation: "Graduated"
   testproj: 
     order: 50
-    active: false
+    active: true
     logo_url: "https://raw.githubusercontent.com/cncf/artwork/master/other/cncf/horizontal/color/cncf-color.svg?sanitize=true"
     display_name: Test Project
     sub_title: Testing


### PR DESCRIPTION
### [Enhancement] Change status of etcd to Graduated

**Short Description:** 
- "Congrats to @etcdio the newest #CNCF project graduate!"
- Issue https://github.com/crosscloudci/crosscloudci/issues/230

**Expected behavior**
- Currently on cncf.ci, etcd is listed as Incubating
- I would like to see etcd listed as Graduated, listed in alphabetical order with other Graduated projects

Graduated Projects: 
- CoreDNS
- Envoy
- etcd
- Fluentd
- ...

**Changes Made**
- [x] update cncf_relation to graduated from incubating
- [x] reorder projects to etcd displays under envoy and before fluentd
- [x] verify staging.cncf.ci shows etcd as graduated and comes after Envoy and before Fluentd; verify at https://staging.cncf.ci


